### PR TITLE
Upgraded Dockerfile image to gmedders/cpp_scientific_libraries:v0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # OS image
-FROM gmedders/cpp_scientific_libraries:v0.1.3
+FROM gmedders/cpp_scientific_libraries:v0.2.0
 
 MAINTAINER gmedders "https://github.com/gmedders"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 ADD . /app
 
 # Build the packaged
-RUN mkdir build && cd build && cmake .. && make
+RUN mkdir build && cd build && cmake .. && make && rm -rf nlohmann*
 
 # When the image is run, go directly to the executables
 WORKDIR /app/build


### PR DESCRIPTION
I worked some on the Docker image and cut the size down from 495MB to 275MB. Should make the docker version less painful